### PR TITLE
updates ts-node-dev flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/app.js",
   "scripts": {
     "tsc": "tsc",
-    "dev": "ts-node-dev --respawn --transpileOnly ./app/app.ts",
+    "dev": "ts-node-dev --respawn --transpile-only ./app/app.ts",
     "prod": "tsc && node ./build/app.js"
   },
   "author": "Xero Platform Team",


### PR DESCRIPTION
Running the `npm run dev` script in the project currently fails because the flag for transpile only mode in [ts-node](https://github.com/TypeStrong/ts-node) has changed from `--transpileOnly` to `--transpile-only`. The short flag `-T` would also work.